### PR TITLE
Fix deployment as described in issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,21 @@ kubectl create secret generic kube-config --from-file=config --dry-run -oyaml | 
 
 # Create deployment file
 cat << EOF > namespace-provisioner.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: namespace-provisioner
+  name: namespace-provisioner-deployment
   labels:
-    name: namespace-provisioner
+    app: namespace-provisioner
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: namespace-provisioner
   template:
     metadata:
       labels:
-        name: namespace-provisioner
+        app: namespace-provisioner
     spec:
       containers:
       - name: namespace-provisioner
@@ -139,6 +142,8 @@ kubectl apply -f namespace-provisioner.yaml
 
 For every annotated namespace, all traffic from app _prometheus_ in namespace _kube-system_ to any pod should be allowed.
 Therefore the namespace provisioner should create a corresponding NetworkPolicy.
+
+Please note that the example might require adaptions depending on your Kubernetes version.
 
 Prepare the corresponding namespace-provisioner config in default namespace:
 

--- a/deploy/namespace-provisioner-minikube.yaml
+++ b/deploy/namespace-provisioner-minikube.yaml
@@ -1,16 +1,19 @@
 # SPDX-License-Identifier: MIT
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: namespace-provisioner
+  name: namespace-provisioner-deployment
   labels:
-    name: namespace-provisioner
+    app: namespace-provisioner
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: namespace-provisioner
   template:
     metadata:
       labels:
-        name: namespace-provisioner
+        app: namespace-provisioner
     spec:
       containers:
       - name: namespace-provisioner


### PR DESCRIPTION
The `apiVersion` for namespace-provisioner deployment was set to `apps/v1` as `extensions/v1beta1` was removed in k8s 1.16. The new version `apps/v1` will work for k8s versions >= 1.9.0. Some additional required or minor changes in deployment were also made.