### PR TITLE
Added sundown notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <!-- SPDX-License-Identifier: MIT -->
+# :warning: This project is no longer maintained and is archived.
+
 # Namespace Provisioner
 
 [![CI](https://github.com/Daimler/namespace-provisioner/workflows/CI/badge.svg)](https://github.com/Daimler/namespace-provisioner/actions?query=workflow%3ACI)


### PR DESCRIPTION
As will sundown the repo in the near future, I added a corresponding notice into the readme.

Oliver Grüneberg <<oliver.grueneberg@daimler.com>>, Daimler TSS GmbH
[Legal Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md) 